### PR TITLE
Updated remote-url input component

### DIFF
--- a/app/components/form/input-fields/remote-urls/edit.hbs
+++ b/app/components/form/input-fields/remote-urls/edit.hbs
@@ -35,11 +35,6 @@
               <a href={{file.remoteUrl.address}} target="_blank" rel="noopener"
                  class="u-spacer--bottom--tiny button button--small button--alt"><i class="vi vi-external"></i>Bekijk
                 link</a>
-              {{#if file.remoteUrl.replicatedFile.downloadLink}}
-                <a href={{file.remoteUrl.replicatedFile.downloadLink}} download
-                   class="u-spacer--bottom--tiny button button--small button--alt"><i
-                        class="vi vi-document-small"></i>Download opgeslagen pagina<sup>*</sup></a>
-              {{/if}}
               <a class="toggle u-spacer--bottom--tiny button button--small button--alt button--alt--warning" {{on
                       "click" (fn this.removeRemoteUrl file)}} role="button"><i class="vi vi-cross vi-u-xs"></i>Verwijder&nbsp;link</a>
             </div>

--- a/app/components/form/input-fields/remote-urls/edit.hbs
+++ b/app/components/form/input-fields/remote-urls/edit.hbs
@@ -4,29 +4,28 @@
   {{#each this.remoteUrls as |file|}}
     <tr>
       <td>
-
         <Input
-                class="input-field input-field--block input-field--small"
-                placeholder="http://wwww.uw-bestuur.be/specifiek-document"
-                value={{file.address}}
-                @focus-out={{fn this.updateRemoteUrl file}}
+          class="input-field input-field--block input-field--small"
+          placeholder="http://wwww.uw-bestuur.be/specifiek-document"
+          value={{file.address}}
+          @focus-out={{fn this.updateRemoteUrl file}}
         />
         <div class="au-o-grid">
           <div class="au-o-grid__item au-u-1-3">
             {{#if file.validation}}
-              <p class="small u-spacer--tb--tinier form__error">Ongeldige link. Ongeldige links worden niet
-                behandeld.</p>
-              <p class="small u-spacer--bottom--tinier">Zorg dat vooraan in de link altijd http://, https://, ftp://
-                of sftp:// staat.</p>
+              <p class="small u-spacer--tb--tinier form__error">Ongeldige link. Ongeldige links worden niet behandeld.</p>
+              <p class="small u-spacer--bottom--tinier">Zorg dat vooraan in de link altijd http://, https://, ftp:// of sftp:// staat.</p>
             {{/if}}
           </div>
           <div class="au-o-grid__item au-u-1-3">
             <div class="button-group u-spacer--top--tiny u-align-right">
-              <a href={{file.address}} target="_blank" rel="noopener"
-                 class="u-spacer--bottom--tiny button button--small button--alt"><i class="vi vi-external"></i>Bekijk
-                link</a>
-              <a class="toggle u-spacer--bottom--tiny button button--small button--alt button--alt--warning" {{on
-                      "click" (fn this.removeRemoteUrl file)}} role="button"><i class="vi vi-cross vi-u-xs"></i>Verwijder&nbsp;link</a>
+              <a href={{file.address}} target="_blank" rel="noopener noreferrer"
+                class="u-spacer--bottom--tiny button button--small button--alt">
+                <i class="vi vi-external"></i> Bekijk link
+              </a>
+              <a class="toggle u-spacer--bottom--tiny button button--small button--alt button--alt--warning" {{on "click" (fn this.removeRemoteUrl file)}} role="button">
+                <i class="vi vi-cross vi-u-xs"></i> Verwijder&nbsp;link
+              </a>
             </div>
           </div>
         </div>
@@ -36,16 +35,15 @@
   <tr>
     <td>
       <div class="u-align-center">
-        {{#unless remoteUrls}}
+        {{#unless this.remoteUrls}}
           <p class="u-spacer--tb--tiny">Nog geen links toegevoegd.</p>
         {{/unless}}
-        <button class="button u-spacer--bottom--tiny" {{action "addUrlField"}}>
+        <button type="button" class="button u-spacer--bottom--tiny" {{on "click" this.addUrlField}}>
           <i class="vi vi-plus button__icon" aria-hidden="true"></i> Voeg nieuwe link toe
         </button>
         <div>
           <p class="small u-spacer--top--tiny">Enkel links naar specifieke documenten, geen overzichtspagina's.</p>
-          <p class="small u-spacer--bottom--tiny"><sup>*</sup>Op het moment van versturen, wordt er een versie<br>
-            gedownload van de pagina die op de link te vinden is.</p>
+          <p class="small u-spacer--bottom--tiny"><sup>*</sup>Op het moment van versturen, wordt er een versie<br>gedownload van de pagina die op de link te vinden is.</p>
         </div>
         <div>
           {{#if this.validation}}
@@ -61,7 +59,7 @@
 </table>
 
 {{#if this.errors}}
-  <WuAlert title={{'Something went wrong'}}>
+  <WuAlert title={{'Er liep iets mis'}}>
     <ul>
       {{#each this.errors as |error|}}
         <li>{{error.resultMessage}}</li>

--- a/app/components/form/input-fields/remote-urls/edit.hbs
+++ b/app/components/form/input-fields/remote-urls/edit.hbs
@@ -1,14 +1,4 @@
 <AuLabel {{did-insert this.loadData}}>{{@field.label}}</AuLabel>
-{{#if this.errors}}
-  {{#each this.errors as |error|}}
-    <p class="small u-spacer--tb--tinier form__error">{{error.resultMessage}}</p>
-  {{/each}}
-{{/if}}
-{{#if this.remoteErrors}}
-  {{#each this.remoteErrors as |error|}}
-    <span class="small u-spacer--tb--tinier form__error">{{error.resultMessage}}</span>
-  {{/each}}
-{{/if}}
 <table class="data-table u-spacer--bottom--tiny">
   <tbody data-test-mn="url-box-list">
   {{#each this.remoteUrls as |file|}}
@@ -23,7 +13,7 @@
         />
         <div class="au-o-grid">
           <div class="au-o-grid__item au-u-1-3">
-            {{#if file.errors}}
+            {{#if file.validation}}
               <p class="small u-spacer--tb--tinier form__error">Ongeldige link. Ongeldige links worden niet
                 behandeld.</p>
               <p class="small u-spacer--bottom--tinier">Zorg dat vooraan in de link altijd http://, https://, ftp://
@@ -57,8 +47,25 @@
           <p class="small u-spacer--bottom--tiny"><sup>*</sup>Op het moment van versturen, wordt er een versie<br>
             gedownload van de pagina die op de link te vinden is.</p>
         </div>
+        <div>
+          {{#if this.validation}}
+            {{#each this.validation as |rule|}}
+              <span class="small u-spacer--tb--tinier form__error">{{rule.resultMessage}}</span>
+            {{/each}}
+          {{/if}}
+        </div>
       </div>
     </td>
   </tr>
   </tbody>
 </table>
+
+{{#if this.errors}}
+  <WuAlert title={{'Something went wrong'}}>
+    <ul>
+      {{#each this.errors as |error|}}
+        <li>{{error.resultMessage}}</li>
+      {{/each}}
+    </ul>
+  </WuAlert>
+{{/if}}

--- a/app/components/form/input-fields/remote-urls/edit.hbs
+++ b/app/components/form/input-fields/remote-urls/edit.hbs
@@ -18,7 +18,7 @@
         <Input
                 class="input-field input-field--block input-field--small"
                 placeholder="http://wwww.uw-bestuur.be/specifiek-document"
-                value={{file.remoteUrl.address}}
+                value={{file.address}}
                 @focus-out={{fn this.updateRemoteUrl file}}
         />
         <div class="au-o-grid">
@@ -32,7 +32,7 @@
           </div>
           <div class="au-o-grid__item au-u-1-3">
             <div class="button-group u-spacer--top--tiny u-align-right">
-              <a href={{file.remoteUrl.address}} target="_blank" rel="noopener"
+              <a href={{file.address}} target="_blank" rel="noopener"
                  class="u-spacer--bottom--tiny button button--small button--alt"><i class="vi vi-external"></i>Bekijk
                 link</a>
               <a class="toggle u-spacer--bottom--tiny button button--small button--alt button--alt--warning" {{on

--- a/app/components/form/input-fields/remote-urls/edit.js
+++ b/app/components/form/input-fields/remote-urls/edit.js
@@ -141,6 +141,10 @@ export default class FormInputFieldsRemoteUrlsEditComponent extends Component {
 
   @action
   async removeRemoteUrl(current) {
-    this.removeRemoteDataObject(current)
+    if (current.value) {
+      this.removeRemoteDataObject(current)
+    } else {
+      this.remoteUrls = [];
+    }
   }
 }

--- a/app/components/form/input-fields/remote-urls/edit.js
+++ b/app/components/form/input-fields/remote-urls/edit.js
@@ -26,7 +26,7 @@ export default class FormInputFieldsRemoteUrlsEditComponent extends Component {
   errors = [];
 
   @tracked
-  remoteErrors = [];
+  validation = [];
 
   @action
   async loadData() {
@@ -41,26 +41,26 @@ export default class FormInputFieldsRemoteUrlsEditComponent extends Component {
 
 
     this.loadValidations();
-    await this.loadProvidedValue();
+    this.loadProvidedValue();
   }
 
   loadValidations() {
-    this.errors = validationResultsForField(this.args.field.uri, this.storeOptions).filter(r => !r.valid);
+    this.validation = validationResultsForField(this.args.field.uri, this.storeOptions).filter(r => !r.valid);
   }
 
-  async loadProvidedValue() {
+  loadProvidedValue() {
     const matches = triplesForPath(this.storeOptions);
     const uris = matches.triples.filter(t => t.predicate.value === DCT("hasPart").value).map(t => t.object);
 
     for (let uri of uris) {
       try {
-        let remoteUrl = await this.retrieveRemoteDataObject(uri, matches.triples)
+        let remoteUrl = this.retrieveRemoteDataObject(uri, matches.triples)
         this.remoteUrls.pushObject({
           ...this.retrieveRemoteDataObject(uri),
-          errors: this.validationResultsForAddress(remoteUrl.address),
+          validation: this.validationResultsForAddress(remoteUrl.address),
         });
       } catch (error) {
-        this.remoteErrors.pushObject({resultMessage: "Er ging iets fout bij het ophalen van de addressen."});
+        this.errors.pushObject({resultMessage: "Er ging iets fout bij het ophalen van de addressen."});
       }
     }
   }
@@ -112,13 +112,14 @@ export default class FormInputFieldsRemoteUrlsEditComponent extends Component {
     this.storeOptions.store.removeStatements(statements);
   }
 
-  // TODO update to the new syntax I'll be introducing
   @action
   addUrlField() {
-    this.remoteUrls.pushObject({uri: null, address: null, errors: []});
+    this.remoteUrls.pushObject({
+      uri: null,
+      address: null,
+    });
   }
 
-  // TODO remove all ember-data stuff
   @action
   async updateRemoteUrl(current, newValue) {
     if (current.remoteUrl && current.remoteUrl.address === newValue.trim()) return; //do nothing if no change
@@ -129,7 +130,6 @@ export default class FormInputFieldsRemoteUrlsEditComponent extends Component {
     this.insertRemoteDataObject(newValue.trim());
   }
 
-  // TODO remove ember-data stuff
   @action
   async removeRemoteUrl(current) {
     this.removeRemoteDataObject(current)

--- a/app/components/form/input-fields/remote-urls/edit.js
+++ b/app/components/form/input-fields/remote-urls/edit.js
@@ -80,6 +80,15 @@ export default class FormInputFieldsRemoteUrlsEditComponent extends Component {
     }
   }
 
+  validationResultsForAddress(value) {
+    return validationResultsForFieldPart(
+      {
+        values: [{value}]
+      },
+      this.args.field.uri,
+      this.storeOptions).filter(r => !r.valid);
+  }
+
   insertRemoteDataObject(address) {
     const uri = new rdflib.NamedNode(`${REMOTE_URI_TEMPLATE}${uuidv4()}`);
     const triples = [
@@ -133,14 +142,5 @@ export default class FormInputFieldsRemoteUrlsEditComponent extends Component {
   @action
   async removeRemoteUrl(current) {
     this.removeRemoteDataObject(current)
-  }
-
-  validationResultsForAddress(value) {
-    return validationResultsForFieldPart(
-      {
-        values: [{value}]
-      },
-      this.args.field.uri,
-      this.storeOptions).filter(r => !r.valid);
   }
 }

--- a/app/components/form/input-fields/remote-urls/edit.js
+++ b/app/components/form/input-fields/remote-urls/edit.js
@@ -10,7 +10,7 @@ import {
 
 import {DCT, NIE} from '../../../../utils/namespaces';
 import rdflib from 'ember-rdflib';
-import uuidv4 from "uuid/v4";
+import { v4 as uuidv4 } from 'uuid';
 
 const REMOTE_URI_TEMPLATE = 'http://data.lblod.info/remote-url/';
 

--- a/app/components/form/input-fields/remote-urls/edit.js
+++ b/app/components/form/input-fields/remote-urls/edit.js
@@ -5,15 +5,15 @@ import {inject as service} from '@ember/service';
 import {
   triplesForPath,
   validationResultsForField,
-  validationResultsForFieldPart,
-  addSimpleFormValue,
-  removeSimpleFormValue
+  validationResultsForFieldPart
 } from '../../../../utils/import-triples-for-form';
 
-import { RDF } from '../../../../utils/namespaces';
+import {DCT, NIE, RDF} from '../../../../utils/namespaces';
 import rdflib from 'ember-rdflib';
+import uuidv4 from "uuid/v4";
 
 const CREATOR_URI = "http://lblod.data.gift/fronted-end-componets/remote-url-creator";
+const REMOTE_URI_TEMPLATE = 'http://data.lblod.info/remote-url/';
 
 export default class FormInputFieldsRemoteUrlsEditComponent extends Component {
 
@@ -54,9 +54,10 @@ export default class FormInputFieldsRemoteUrlsEditComponent extends Component {
 
     for (let uri of matches.values) {
       try {
-        if(!this.isRemoteDataObject(uri)) continue;
-        const remotes = await this.store.query('remote-url', {'filter[:uri:]': uri.value});
-        const remoteUrl = remotes.get('firstObject');
+        if (!this.isRemoteDataObject(uri)) continue;
+        let remotes = await this.store.query('remote-url', {'filter[:uri:]': uri.value});
+        // TODO somehow this objects gets a rdflib syntax??
+        let remoteUrl = remotes.get('firstObject');
         if (remoteUrl) {
           this.remoteUrls.pushObject({
             remoteUrl,
@@ -64,40 +65,65 @@ export default class FormInputFieldsRemoteUrlsEditComponent extends Component {
             uri
           });
         } else {
-          this.remoteErrors.pushObject({resultMessage : "Er ging iets fout bij het ophalen van de addressen."});
+          // TODO try to retrieve it from local + simplify
+          remotes = await this.store.peekAll('remote-url').filter(remote => remote.uri === uri.value);
+          remoteUrl = remotes.get('firstObject');
+          if(remoteUrl){
+            this.remoteUrls.pushObject({
+              remoteUrl,
+              errors: this.validationResultsForAddress(remoteUrl.address),
+              uri
+            });
+          } else {
+            this.remoteErrors.pushObject({resultMessage: "Er ging iets fout bij het ophalen van de addressen."});
+          }
         }
       } catch (error) {
-        this.remoteErrors.pushObject({resultMessage : "Er ging iets fout bij het ophalen van de addressen."});
+        this.remoteErrors.pushObject({resultMessage: "Er ging iets fout bij het ophalen van de addressen."});
       }
 
     }
   }
 
-  isRemoteDataObject(subject){
+  isRemoteDataObject(subject) {
     return this.storeOptions.store.match(subject,
-                                         RDF('type'),
-                                         new rdflib.NamedNode('http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject'),
-                                         this.storeOptions.sourceGraph).length > 0;
+      RDF('type'),
+      new rdflib.NamedNode('http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject'),
+      this.storeOptions.sourceGraph).length > 0;
   }
 
-  insertRemoteDataObject(remoteObjUri){
-    const typeT = { subject: new rdflib.NamedNode(remoteObjUri),
-                    predicate: RDF('type'),
-                    object: new rdflib.NamedNode('http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject'),
-                    graph: this.storeOptions.sourceGraph
-                  };
-    this.storeOptions.store.addAll([ typeT ]);
-    addSimpleFormValue(new rdflib.NamedNode(remoteObjUri), this.storeOptions);
+  // TODO change this to save the correct data in the rdflib form
+  insertRemoteDataObject(remoteObj) {
+    const triples = [
+      {
+        subject: new rdflib.NamedNode(remoteObj.uri),
+        predicate: RDF('type'),
+        object: new rdflib.NamedNode('http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject'),
+        graph: this.storeOptions.sourceGraph
+      },
+      {
+        subject: this.storeOptions.sourceNode,
+        predicate: DCT('hasPart'),
+        object: new rdflib.NamedNode(remoteObj.uri),
+        graph: this.storeOptions.sourceGraph
+      },
+      {
+        subject: new rdflib.NamedNode(remoteObj.uri),
+        predicate: NIE('url'),
+        object: remoteObj.address,
+        graph: this.storeOptions.sourceGraph
+      }];
+    this.storeOptions.store.addAll(triples);
   }
 
-  removeRemoteDataObject(remoteObjUri){
-    const typeT = { subject: new rdflib.NamedNode(remoteObjUri),
-                    predicate: RDF('type'),
-                    object: new rdflib.NamedNode('http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject'),
-                    graph: this.storeOptions.sourceGraph
-                  };
-    this.storeOptions.store.removeStatements([ typeT ]);
-    removeSimpleFormValue(new rdflib.NamedNode(remoteObjUri), this.storeOptions);
+  // TODO change this to remove the correct data in the rdflib form
+  removeRemoteDataObject(remoteObjUri) {
+    const uri = new rdflib.NamedNode(remoteObjUri);
+    const statements = [
+      ...this.storeOptions.store.match(uri, undefined, undefined, this.storeOptions.sourceGraph),
+      { subject: this.storeOptions.sourceNode, predicate: DCT('hasPart'), object: uri, graph: this.storeOptions.sourceGraph }
+    ];
+    this.storeOptions.store.removeStatements(statements);
   }
 
   @action
@@ -108,33 +134,26 @@ export default class FormInputFieldsRemoteUrlsEditComponent extends Component {
   @action
   async updateRemoteUrl(current, newValue) {
 
-    if (current.remoteUrl && current.remoteUrl.address == newValue.trim()) return; //do nothing if no change
+    if (current.remoteUrl && current.remoteUrl.address === newValue.trim()) return; //do nothing if no change
 
     //for every url update we should make a new remote-url. This is how the model is
     const address = newValue.trim();
     const newRemoteUrl = this.createNewRemoteUrl(address);
 
-    try {
-        await newRemoteUrl.save();
-      } catch (error) {
-        this.remoteErrors.pushObject({resultMessage: "Er ging iets fout bij het opslaan."});
-        return;
-    }
-
     //If there was a previous, remove this from the store
-    if(current.uri){
+    if (current.uri) {
       await current.remoteUrl.destroyRecord();
       this.removeRemoteDataObject(current.uri.value);
     }
 
-    this.insertRemoteDataObject(newRemoteUrl.uri);
+    this.insertRemoteDataObject(newRemoteUrl);
   }
 
   @action
   async removeRemoteUrl(current) {
-    if(current.remoteUrl) {
+    if (current.remoteUrl) {
       await current.remoteUrl.destroyRecord();
-       this.removeRemoteDataObject(current.uri.value);
+      this.removeRemoteDataObject(current.uri.value);
     } else {
       this.remoteUrls = [];
     }
@@ -142,6 +161,7 @@ export default class FormInputFieldsRemoteUrlsEditComponent extends Component {
 
   createNewRemoteUrl(address) {
     return this.store.createRecord('remote-url', {
+      uri: `${REMOTE_URI_TEMPLATE}${uuidv4()}`,
       creator: CREATOR_URI,
       address
     });

--- a/app/components/form/input-fields/remote-urls/edit.js
+++ b/app/components/form/input-fields/remote-urls/edit.js
@@ -15,21 +15,16 @@ import { v4 as uuidv4 } from 'uuid';
 const REMOTE_URI_TEMPLATE = 'http://data.lblod.info/remote-url/';
 
 export default class FormInputFieldsRemoteUrlsEditComponent extends Component {
+  @service store
 
-  @service
-  store;
+  @tracked remoteUrls = []
 
-  @tracked
-  remoteUrls = [];
+  @tracked errors = []
 
-  @tracked
-  errors = [];
-
-  @tracked
-  validation = [];
+  @tracked validation = []
 
   @action
-  async loadData() {
+  loadData() {
     this.storeOptions = {
       formGraph: this.args.graphs.formGraph,
       sourceNode: this.args.sourceNode,
@@ -38,7 +33,6 @@ export default class FormInputFieldsRemoteUrlsEditComponent extends Component {
       store: this.args.formStore,
       path: this.args.field.rdflibPath
     };
-
 
     this.loadValidations();
     this.loadProvidedValue();
@@ -54,11 +48,9 @@ export default class FormInputFieldsRemoteUrlsEditComponent extends Component {
 
     for (let uri of uris) {
       try {
-        let remoteUrl = this.retrieveRemoteDataObject(uri, matches.triples)
-        this.remoteUrls.pushObject({
-          ...this.retrieveRemoteDataObject(uri),
-          validation: this.validationResultsForAddress(remoteUrl.address),
-        });
+        let remoteUrl = this.retrieveRemoteDataObject(uri);
+        remoteUrl.validation = this.validationResultsForAddress(remoteUrl.address);
+        this.remoteUrls.pushObject(remoteUrl);
       } catch (error) {
         this.errors.pushObject({resultMessage: "Er ging iets fout bij het ophalen van de addressen."});
       }
@@ -73,8 +65,8 @@ export default class FormInputFieldsRemoteUrlsEditComponent extends Component {
     if (addresses.length !== 0) {
       return {
         uri,
-        address: addresses.get('firstObject')
-      }
+        address: addresses[0]
+      };
     } else {
       throw `No remote-url could be found for ${uri}`;
     }
@@ -141,6 +133,6 @@ export default class FormInputFieldsRemoteUrlsEditComponent extends Component {
 
   @action
   async removeRemoteUrl(current) {
-    this.removeRemoteDataObject(current)
+    this.removeRemoteDataObject(current);
   }
 }

--- a/app/components/form/input-fields/remote-urls/show.hbs
+++ b/app/components/form/input-fields/remote-urls/show.hbs
@@ -11,8 +11,8 @@
         />
         <div class="button-group u-spacer--top--tiny">
           <a href={{file.remoteUrl.address}} target="_blank" rel="noopener" class="u-spacer--bottom--tiny button button--small button--alt"><i class="vi vi-external"></i>Bekijk link</a>
-          {{#if file.remoteUrl.replicatedFile.downloadLink}}
-            <a href={{file.remoteUrl.replicatedFile.downloadLink}} download class="u-spacer--bottom--tiny button button--small button--alt"><i class="vi vi-document-small"></i>Download opgeslagen pagina<sup>*</sup></a>
+          {{#if file.remoteUrl.downloadLink}}
+            <a href={{file.remoteUrl.downloadLink}} download class="u-spacer--bottom--tiny button button--small button--alt"><i class="vi vi-document-small"></i>Download opgeslagen pagina<sup>*</sup></a>
           {{/if}}
         </div>
       </td>

--- a/app/components/form/input-fields/remote-urls/show.hbs
+++ b/app/components/form/input-fields/remote-urls/show.hbs
@@ -6,13 +6,13 @@
       <td>
         <Input
                 class="input-field input-field--block input-field--small"
-                @value={{file.remoteUrl.address}}
+                @value={{file.address}}
                 @disabled={{true}}
         />
         <div class="button-group u-spacer--top--tiny">
-          <a href={{file.remoteUrl.address}} target="_blank" rel="noopener" class="u-spacer--bottom--tiny button button--small button--alt"><i class="vi vi-external"></i>Bekijk link</a>
-          {{#if file.remoteUrl.downloadLink}}
-            <a href={{file.remoteUrl.downloadLink}} download class="u-spacer--bottom--tiny button button--small button--alt"><i class="vi vi-document-small"></i>Download opgeslagen pagina<sup>*</sup></a>
+          <a href={{file.address}} target="_blank" rel="noopener" class="u-spacer--bottom--tiny button button--small button--alt"><i class="vi vi-external"></i>Bekijk link</a>
+          {{#if file.downloadLink}}
+            <a href={{file.downloadLink}} download class="u-spacer--bottom--tiny button button--small button--alt"><i class="vi vi-document-small"></i>Download opgeslagen pagina<sup>*</sup></a>
           {{/if}}
         </div>
       </td>

--- a/app/components/form/input-fields/remote-urls/show.hbs
+++ b/app/components/form/input-fields/remote-urls/show.hbs
@@ -25,3 +25,13 @@
 {{else}}
   <p class="small u-spacer--bottom--tiny text-fade">Er werden geen links toegevoegd.</p>
 {{/if}}
+
+{{#if this.errors}}
+  <WuAlert title={{'Something went wrong'}}>
+    <ul>
+      {{#each this.errors as |error|}}
+        <li>{{error.resultMessage}}</li>
+      {{/each}}
+    </ul>
+  </WuAlert>
+{{/if}}

--- a/app/components/form/input-fields/remote-urls/show.hbs
+++ b/app/components/form/input-fields/remote-urls/show.hbs
@@ -27,7 +27,7 @@
 {{/if}}
 
 {{#if this.errors}}
-  <WuAlert title={{'Something went wrong'}}>
+  <WuAlert title={{'Er liep iets mis'}}>
     <ul>
       {{#each this.errors as |error|}}
         <li>{{error.resultMessage}}</li>

--- a/app/components/form/input-fields/remote-urls/show.js
+++ b/app/components/form/input-fields/remote-urls/show.js
@@ -14,6 +14,9 @@ export default class FormInputFieldsRemoteUrlsShowComponent extends Component {
   @tracked
   remoteUrls = [];
 
+  @tracked
+  errors = [];
+
   @action
   async loadData() {
     this.storeOptions = {
@@ -38,7 +41,7 @@ export default class FormInputFieldsRemoteUrlsShowComponent extends Component {
           await this.retrieveRemoteDataObject(uri, matches.triples)
         );
       } catch (error) {
-        this.remoteErrors.pushObject({resultMessage: "Er ging iets fout bij het ophalen van de addressen."});
+        this.error.pushObject({resultMessage: "Er ging iets fout bij het ophalen van de addressen."});
       }
     }
   }

--- a/app/components/form/input-fields/remote-urls/show.js
+++ b/app/components/form/input-fields/remote-urls/show.js
@@ -7,15 +7,11 @@ import {triplesForPath} from "../../../../utils/import-triples-for-form";
 import {DCT} from "../../../../utils/namespaces";
 
 export default class FormInputFieldsRemoteUrlsShowComponent extends Component {
+  @service store
 
-  @service
-  store;
+  @tracked remoteUrls = []
 
-  @tracked
-  remoteUrls = [];
-
-  @tracked
-  errors = [];
+  @tracked errors = []
 
   @action
   async loadData() {
@@ -47,8 +43,11 @@ export default class FormInputFieldsRemoteUrlsShowComponent extends Component {
   }
 
   async retrieveRemoteDataObject(uri) {
-    let remotes = await this.store.query('remote-url', {'filter[:uri:]': uri.value});
-    if (remotes.length !== 0) {
+    let remotes = await this.store.query('remote-url', {
+      'filter[:uri:]': uri.value,
+      page: { size: 1 }
+    });
+    if (remotes.length) {
       return remotes.get('firstObject');
     } else {
       throw `No remote-url could be found for ${uri}`;

--- a/app/components/form/input-fields/remote-urls/show.js
+++ b/app/components/form/input-fields/remote-urls/show.js
@@ -1,5 +1,54 @@
-import FormInputFieldsFileAddressesEditComponent from "./edit";
+import Component from "@glimmer/component";
+import {tracked} from '@glimmer/tracking';
+import {action} from '@ember/object';
+import {inject as service} from '@ember/service';
 
-export default class FormInputFieldsFileAddressesShowComponent extends FormInputFieldsFileAddressesEditComponent {
+import {triplesForPath} from "../../../../utils/import-triples-for-form";
+import {DCT} from "../../../../utils/namespaces";
 
+export default class FormInputFieldsRemoteUrlsShowComponent extends Component {
+
+  @service
+  store;
+
+  @tracked
+  remoteUrls = [];
+
+  @action
+  async loadData() {
+    this.storeOptions = {
+      formGraph: this.args.graphs.formGraph,
+      sourceNode: this.args.sourceNode,
+      sourceGraph: this.args.graphs.sourceGraph,
+      metaGraph: this.args.graphs.metaGraph,
+      store: this.args.formStore,
+      path: this.args.field.rdflibPath
+    };
+
+    await this.loadProvidedValue();
+  }
+
+  async loadProvidedValue() {
+    const matches = triplesForPath(this.storeOptions);
+    const uris = matches.triples.filter(t => t.predicate.value === DCT("hasPart").value).map(t => t.object);
+
+    for (let uri of uris) {
+      try {
+        this.remoteUrls.pushObject(
+          await this.retrieveRemoteDataObject(uri, matches.triples)
+        );
+      } catch (error) {
+        this.remoteErrors.pushObject({resultMessage: "Er ging iets fout bij het ophalen van de addressen."});
+      }
+    }
+  }
+
+  async retrieveRemoteDataObject(uri) {
+    let remotes = await this.store.query('remote-url', {'filter[:uri:]': uri.value});
+    if (remotes.length !== 0) {
+      return remotes.get('firstObject');
+    } else {
+      throw `No remote-url could be found for ${uri}`;
+    }
+  }
 }

--- a/app/components/form/input-fields/vlabel-opcentiem/edit.js
+++ b/app/components/form/input-fields/vlabel-opcentiem/edit.js
@@ -8,7 +8,7 @@ import {
   validationResultsForField
 } from '../../../../utils/import-triples-for-form';
 import rdflib from 'ember-rdflib';
-import uuidv4 from 'uuid/v4';
+import { v4 as uuidv4 } from 'uuid';
 import { RDF, XSD } from '../../../../utils/namespaces';
 
 const uriTemplate = 'http://data.lblod.info/tax-rates';

--- a/app/models/remote-url.js
+++ b/app/models/remote-url.js
@@ -7,7 +7,7 @@ export default Model.extend({
   address: attr(),
   created: attr('date'),
   modified: attr('date'),
-  replicatedFile: belongsTo('file', { inverse: null }),
+  download: belongsTo('file', { inverse: null }),
   downloadStatus: attr(),
   creator: attr(),
 

--- a/app/models/remote-url.js
+++ b/app/models/remote-url.js
@@ -1,4 +1,5 @@
 import DS from 'ember-data';
+import { computed } from '@ember/object';
 const { Model, attr, belongsTo } = DS;
 
 export default Model.extend({
@@ -9,4 +10,8 @@ export default Model.extend({
   replicatedFile: belongsTo('file', { inverse: null }),
   downloadStatus: attr(),
   creator: attr(),
+
+  downloadLink: computed('filename', function () {
+    return `/files/${this.id}/download`;
+  })
 });

--- a/app/utils/import-triples-for-form.js
+++ b/app/utils/import-triples-for-form.js
@@ -1,7 +1,7 @@
 import { RDF, FORM, SHACL } from './namespaces';
 import { check, checkTriples } from './constraints';
 import rdflib from 'ember-rdflib';
-import uuidv4 from 'uuid/v4';
+import { v4 as uuidv4 } from 'uuid';
 
 const URI_TEMPLATE = 'http://data.lblod.info/form-data/nodes/';
 

--- a/app/utils/namespaces.js
+++ b/app/utils/namespaces.js
@@ -5,5 +5,7 @@ const FORM = new rdflib.Namespace("http://lblod.data.gift/vocabularies/forms/");
 const SHACL = new rdflib.Namespace("http://www.w3.org/ns/shacl#");
 const SKOS = new rdflib.Namespace("http://www.w3.org/2004/02/skos/core#");
 const XSD = new rdflib.Namespace("http://www.w3.org/2001/XMLSchema#");
+const DCT = new rdflib.Namespace("http://purl.org/dc/terms/");
+const NIE = new rdflib.Namespace("http://www.semanticdesktop.org/ontologies/2007/01/19/nie#");
 
-export { RDF, FORM, SHACL, SKOS, XSD };
+export { RDF, FORM, SHACL, SKOS, XSD, DCT, NIE };

--- a/package.json
+++ b/package.json
@@ -79,6 +79,6 @@
   },
   "dependencies": {
     "ember-moment": "^8.0.0",
-    "uuid": "^3.4.0"
+    "uuid": "^7.0.2"
   }
 }


### PR DESCRIPTION
`remote-url` component will now,  on add of a new remote address, not save them in the triple-store by calling the `remote-url` resource. Instead it will rely on the back-end do so.