### PR TITLE
Improved loading screens

### DIFF
--- a/app/controllers/mock-login.js
+++ b/app/controllers/mock-login.js
@@ -9,6 +9,7 @@ export default class MockLoginController extends Controller {
   @tracked page = 0;
   @tracked size = 10;
   @service store;
+  @tracked isLoading = false;
 
   @task
   *queryStore() {

--- a/app/routes/mock-login.js
+++ b/app/routes/mock-login.js
@@ -26,6 +26,7 @@ export default class MockLoginRoute extends Route {
     });
   }
 
+  /* eslint-disable ember/no-controller-access-in-routes */
   @action
   async loading(transition) {
     const controller = this.controllerFor('mock-login');
@@ -34,4 +35,5 @@ export default class MockLoginRoute extends Route {
       controller.set('isLoading', false);
     });
   }
+  /* eslint-enable ember/no-controller-access-in-routes */
 }

--- a/app/routes/mock-login.js
+++ b/app/routes/mock-login.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
 
 export default class MockLoginRoute extends Route {
   queryParams = {
@@ -22,6 +23,15 @@ export default class MockLoginRoute extends Route {
       filter: filter,
       page: { size: 10, number: params.page },
       sort: 'gebruiker.achternaam',
+    });
+  }
+
+  @action
+  async loading(transition) {
+    const controller = this.controllerFor('mock-login');
+    controller.set('isLoading', true);
+    transition.promise.finally(function () {
+      controller.set('isLoading', false);
     });
   }
 }

--- a/app/templates/application-loading.hbs
+++ b/app/templates/application-loading.hbs
@@ -7,4 +7,3 @@
     {{t "loading.thanks"}}
   </AuHelpText>
 </div>
-

--- a/app/templates/mock-login.hbs
+++ b/app/templates/mock-login.hbs
@@ -29,9 +29,8 @@
               oninput={{perform this.updateSearch value='target.value'}} />
           {{/let}}
         </p>
-
         <MockLogin as |login|>
-          {{#if this.queryStore.isRunning}}
+          {{#if (or this.queryStore.isRunning this.isLoading)}}
             <AuLoader @padding="small" />
           {{else}}
             {{#if this.login.errorMessage}}


### PR DESCRIPTION
On loading new pages of the mock-login, there is now a small loading indicator instead of the page wide loading screen. 

There is still a problem I couldn't fix. The router is accessing the controller for setting load states. I don't know how else to do this.