### PR TITLE
Fixing submission save issue

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -10,4 +10,12 @@ export default class App extends Application {
   Resolver = Resolver;
 }
 
+// By default `Array.prototype._super` is enumerable which causes conflicts with rdflib.
+// We can force it to be non-enumerable so everything works as expected.
+// This code can be removed once the bug is fixed and released, or if we disable the prototype extensions in the app.
+// More information: https://github.com/emberjs/ember.js/issues/19289
+Object.defineProperty(Array.prototype, '_super', {
+  enumerable: false,
+});
+
 loadInitializers(App, config.modulePrefix);


### PR DESCRIPTION
# Description
DL-5268

This PR fixes the issue where submissions can't be saved due to this error `solid-namespaces__WEBPACK_IMPORTED_MODULE _3___ default()()[nsKeys[i]] is not a function` . 

- Applying workaround  https://github.com/lblod/frontend-loket/blob/ea76b25c8c78e15fca1a37b095b3740b407032f9/app/app.js#L17-L23 Thanks @Windvis 


# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related services

- N/A

# How to test 

1. Start the stack app-meldingsplichtige-api and this branch as frontend on port 80.
2. Pick any administrative unit.
3. Try to save a new submission.

Expected : 

![Screenshot_20230712_161121](https://github.com/lblod/frontend-meldingsplichtige-api/assets/38471754/139a41c8-d123-42bb-8b66-16852afceaa8)

# What to check

- N/A

# Links to other PR's

- N/A

# Notes

When merged release frontend + bump in app-meldingsplichtige-api the frontend image